### PR TITLE
Update localStorage check in Artists

### DIFF
--- a/src/components/Artists.js
+++ b/src/components/Artists.js
@@ -17,7 +17,8 @@ class Artists extends Component {
 
   render() {
     if (this.props.artists) {
-      if (localStorage.getItem('ids').includes(this.props.match.params.id)) {
+      const ids = localStorage.getItem('ids') || '';
+      if (ids.includes(this.props.match.params.id)) {
         return (
           <div>
             <Modal


### PR DESCRIPTION
## Summary
- fix the check for IDs in `Artists` so `.includes` isn't called on null

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0febac3483298bc74206d49e4f6b