### PR TITLE
Fix genre ID caching

### DIFF
--- a/src/components/Genres.js
+++ b/src/components/Genres.js
@@ -17,15 +17,16 @@ class Genres extends Component {
 
   componentDidMount() {
     this.props.fetchGenres();
-    this.componentDidUpdate();
   }
-  componentDidUpdate() {
-    localStorage.setItem('ids', this.genresIds);
+  componentDidUpdate(prevProps) {
+    if (prevProps.genres !== this.props.genres) {
+      this.genresIds = this.props.genres.map(genre => genre.id);
+      localStorage.setItem('ids', this.genresIds);
+    }
   }
 
   renderGenres() {
     return this.props.genres.map(genre => {
-      this.genresIds.push(genre.id);
       return (
         <StyledLink
           to={`/${genre.id}`}


### PR DESCRIPTION
## Summary
- handle genre IDs in componentDidUpdate
- only update localStorage when genres prop changes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0feeed208329b18361ec169ffd90