### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 Demo [https://axmxh.github.io/genres](https://axmxh.github.io/genres) 
 
-After Cloning this repo you can run:
+After cloning this repo you can run the following commands from the repository root:
 ### `yarn install`
-
-### `cd genres`
-
 ### `yarn start`
 
 Runs the app in the development mode.<br />


### PR DESCRIPTION
## Summary
- remove `cd genres` step from README
- clarify that `yarn install` and `yarn start` should be run from the repo root

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn test --watchAll=false` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ff3d43c8329afbf2fc113611991