### PR TITLE
Fix Modal component export

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import Pagination from './Pagination';
 
-const Model = props => {
+const Modal = props => {
   const [current, setCurrent] = useState(1);
   const [perPage] = useState(10);
 
@@ -53,4 +53,4 @@ const Model = props => {
   );
 };
 
-export default Model;
+export default Modal;


### PR DESCRIPTION
## Summary
- rename the component function Model -> Modal
- update default export

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ff154c08329b26b8a9eaae4114c